### PR TITLE
release: add java8 base container

### DIFF
--- a/apps/java8/Dockerfile
+++ b/apps/java8/Dockerfile
@@ -1,0 +1,47 @@
+
+
+
+FROM ghcr.io/trueforge-org/ubuntu:24.4.0@sha256:accb07943840b6a8b3a09886789c72f0121189e7d78e6f954a5c81194318e6c2
+
+# Default to UTF-8 file.encoding
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' JAVA_HOME='/opt/java/openjdk'
+
+ENV  JRE_CACERTS_PATH="$JAVA_HOME/lib/security/cacerts"  PATH="$JAVA_HOME/bin:$PATH"
+
+ARG VERSION
+ARG MAJOR
+ARG FETCH_VERSION=${VERSION//-/}
+
+ARG TARGETARCH
+ARG TARGETARCH=${TARGETARCH/arm64/aarch64}
+ARG TARGETARCH=${TARGETARCH/amd64/x64}
+
+USER root
+
+RUN set -eux; \
+    echo "${LANG} UTF-8" >> /etc/locale.gen; \
+    locale-gen ${LANG}; \
+    BINARY_URL="https://github.com/adoptium/temurin${MAJOR}-binaries/releases/download/jdk${VERSION}/OpenJDK${MAJOR}U-jre_${TARGETARCH}_linux_hotspot_${FETCH_VERSION}.tar.gz"; \
+    wget --progress=dot:giga -O /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    wget --progress=dot:giga -O /tmp/openjdk.tar.gz.sig ${BINARY_URL}.sig; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    # gpg: key 843C48A565F8F04B: "Adoptium GPG Key (DEB/RPM Signing Key) <temurin-dev@eclipse.org>" imported
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 3B04D753C9050D9A5D343F39843C48A565F8F04B; \
+    gpg --batch --verify /tmp/openjdk.tar.gz.sig /tmp/openjdk.tar.gz; \
+    rm -rf "${GNUPGHOME}" /tmp/openjdk.tar.gz.sig; \
+    mkdir -p "$JAVA_HOME"; \
+    tar --extract \
+        --file /tmp/openjdk.tar.gz \
+        --directory "$JAVA_HOME" \
+        --strip-components 1 \
+        --no-same-owner \
+    ; \
+    rm -f /tmp/openjdk.tar.gz; \
+    # https://github.com/docker-library/openjdk/issues/331#issuecomment-498834472
+    find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
+    ldconfig; \
+    # https://github.com/docker-library/openjdk/issues/212#issuecomment-420979840
+    # https://openjdk.java.net/jeps/341
+    java -Xshare:dump;
+
+USER apps:apps

--- a/apps/java8/container_test.go
+++ b/apps/java8/container_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+
+	appName := os.Getenv("APP")
+	require.NotEmpty(t, appName, "APP environment variable must be set")
+	image := os.Getenv("TEST_IMAGE")
+	if image == "" {
+		image = "ghcr.io/trueforge-org/" + appName + ":rolling"
+	}
+
+	app, err := testcontainers.Run(
+		ctx, image,
+		testcontainers.WithCmdArgs("java", "--version"),
+	)
+	testcontainers.CleanupContainer(t, app)
+	require.NoError(t, err)
+}

--- a/apps/java8/docker-bake.hcl
+++ b/apps/java8/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "java8"
+}
+
+variable "VERSION" {
+  default = "8u472-b08"
+}
+
+variable "MAJOR" {
+  default = "8"
+}
+
+variable "LICENSE" {
+  default = "AGPL-3.0-or-later"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/adoptium/temurin17"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+    MAJOR = "${MAJOR}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+    "org.opencontainers.image.licenses" = "${LICENSE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
**Description**
We have a few containers that depend on Java 8 vs 17 or 21

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
