### PR TITLE
fix(nextcloud): remove digest from VERSION variable to enable renovate to update

### DIFF
--- a/apps/nextcloud-fpm/docker-bake.hcl
+++ b/apps/nextcloud-fpm/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "APP" {
 
 variable "VERSION" {
   // renovate: datasource=docker depName=public.ecr.aws/docker/library/nextcloud  versioning=loose
-  default = "32.0.1-fpm@sha256:1b7786935321e01a689affccb48a5845ed800184aa50c1b0c50d4aa75693e27f"
+  default = "32.0.1-fpm"
 }
 
 variable "LICENSE" {


### PR DESCRIPTION
**Description**

Renovate doesn't appear to be able to read the nextcloud version in its current form, and the entry is absent from the dependencies list. I have tried to reproduce this locally on my own repository, and in the debug log, renovate indicated it could not find a digest match. Removing the digest enables renovate to look up the desired version on the public.ecr.aws repository. I cannot see digests published for nexcloud under https://gallery.ecr.aws/docker/library/nextcloud and there are reports from others that renovate cannot access digests from AWS ECR without authentication. 

The change proposed in this PR should allow renovate to process the latest version change. From my local testing I do not believe that the loose versioning is required, but I have left this so as not to introduce too many changes.

I am not able to test whether removing the digest has a downstream effect on the dockerfile build.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Tested locally using a repository to which renovate has access

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
