### PR TITLE
remove whitespace from renovate annotations

### DIFF
--- a/apps/nextcloud-fpm/docker-bake.hcl
+++ b/apps/nextcloud-fpm/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  // renovate: datasource=docker depName=public.ecr.aws/docker/library/nextcloud  versioning=loose
+  // renovate: datasource=docker depName=public.ecr.aws/docker/library/nextcloud versioning=loose
   default = "32.0.1-fpm@sha256:1b7786935321e01a689affccb48a5845ed800184aa50c1b0c50d4aa75693e27f"
 }
 

--- a/apps/nextcloud-imaginary/docker-bake.hcl
+++ b/apps/nextcloud-imaginary/docker-bake.hcl
@@ -9,7 +9,7 @@ variable "VERSION" {
 }
 
 variable "IMAGINARY_COMMMIT" {
-  // renovate: datasource=git-refs depName=https://github.com/h2non/imaginary  versioning=loose
+  // renovate: datasource=git-refs depName=https://github.com/h2non/imaginary versioning=loose
   default = "b632dae8cc321452c3f85bcae79c580b1ae1ed84"
 }
 

--- a/apps/ubuntu/docker-bake.hcl
+++ b/apps/ubuntu/docker-bake.hcl
@@ -9,7 +9,7 @@ variable "VERSION" {
 }
 
 variable "NEO_VER" {
-  // renovate: datasource=github-releases depName=intel/compute-runtime  versioning=loose
+  // renovate: datasource=github-releases depName=intel/compute-runtime versioning=loose
   default = "25.35.35096.9"
 }
 


### PR DESCRIPTION
**Description**

In some renovate annotations there are two whitespaces between depName and versioning, which is probably the reason why these are not picked up by renovate

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
