### PR TITLE
fix(emby): Patch ffmpeg binaries to use right loader

### DIFF
--- a/apps/emby/Dockerfile
+++ b/apps/emby/Dockerfile
@@ -19,8 +19,14 @@ RUN \
     && mv -t /app/bin/ /tmp/emby/opt/emby-server/* \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
         patchelf --set-interpreter /app/bin/lib/ld-linux-x86-64.so.2 /app/bin/system/EmbyServer; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-x86-64.so.2 /app/bin/bin/ffmpeg; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-x86-64.so.2 /app/bin/bin/ffdetect; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-x86-64.so.2 /app/bin/bin/ffprobe; \
     elif [ "${TARGETARCH}" = "arm64" ]; then \
         patchelf --set-interpreter /app/bin/lib/ld-linux-aarch64.so.1 /app/bin/system/EmbyServer; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-aarch64.so.1 /app/bin/bin/ffmpeg; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-aarch64.so.1 /app/bin/bin/ffdetect; \
+        patchelf --set-interpreter /app/bin/lib/ld-linux-aarch64.so.1 /app/bin/bin/ffprobe; \
     else \
         echo "Error: Unsupported architecture: ${TARGETARCH}"; exit 1; \
     fi \


### PR DESCRIPTION
**Description**
<!--
-->
Patch ffmpeg binaries to use the right loader

⚒️ Fixes  # <!--(issue)-->
https://github.com/trueforge-org/containerforge/issues/1365

**⚙️ Type of change**

- [ ] 🧰 New container/image
- [ ] 🛠️ Update existing container/image
- [x] 🐛 Bugfix (Dockerfile, scripts, chart values)
- [ ] 🔃 Refactor (no functional change)
- [ ] ⚠️ Breaking change (image tag, chart API change)

**🧪 How Has This Been Tested?**
<!--
-->
Patched binaries locally in my container and execution was successful

- [ ] ✅ Built container locally
- [ ] ✅ Ran container tests (unit/integration)
- [ ] ✅ Verified image in staging environment
- [ ] ✅ Checked container logs for errors

**📃 Notes**
<!-- Add any additional information like environment variables, optional args, or migration notes -->

**✔️ Checklist:**

- [ ] ⚖️ Changes follow the style guidelines of this project
- [ ] 👀 Self-review completed
- [ ] ✍️ Dockerfile and scripts are clear and accurate
- [ ] 🔗 Internal references (base images) are correct
- [ ] 🧪 Test instructions included
- [ ] 🏷️ The PR title follows the convention:
  - `feat(page):`
  - `fix(content):`
  - `docs(site):`
  - `chore(site):`

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
