### PR TITLE
fix(home-assistant): replace libgpiod2 with libgpiod3 for Ubuntu 26.04

### DIFF
--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux; \
         iputils-ping \
         libcap2 \
         libftdi1 \
-        libgpiod2 \
+        libgpiod3 \
         libturbojpeg0-dev \
         libpulse0 \
         libstdc++6 \


### PR DESCRIPTION
## Summary

- `libgpiod2` was renamed to `libgpiod3` in Ubuntu 26.04 (resolute) following a libgpiod 2.x SONAME bump
- The base image `ghcr.io/trueforge-org/python:3.14.4` was rebuilt against Ubuntu 26.04, causing `apt-get install libgpiod2` to fail with `E: Unable to locate package libgpiod2`
- This fixes the build failure seen in CI run 26014942137 and blocking Renovate PR #2342

## Test plan

- [x] Local `docker build --build-arg VERSION=2026.5.1` completed successfully
- [x] All apt packages resolved, including `libgpiod3`
- [x] All pip installs completed, `homeassistant-2026.5.1` installed cleanly on Python 3.14